### PR TITLE
Remove the default features of the image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/aiueo13/image-overlay"
 [dependencies]
 paste = "1.0.15"
 pcg-mwc = "0.2.1"
-image = ">=0.25"
+image = { version = ">=0.25", default-features = false }
 serde = { version = "1.0.214", optional = true, features = ["derive"] }
 
 [features]


### PR DESCRIPTION
Hi, nice handy crate you got there !

Maybe consider removing the default features of the `image` crate, there are a LOT of optional image formats (some more obscure than others), and having +60 dependencies really hurt the compile time and the binary size.
The choice should be left to the parent crate.